### PR TITLE
feat(auth): add sign-in and sign-up forms and pages

### DIFF
--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,0 +1,7 @@
+import { SignInForm } from "@/modules/auth/components/sign-in-form";
+import { requireNoAuth } from "@/modules/auth/lib/auth.utils";
+
+export default async function SignInPage() {
+  await requireNoAuth();
+  return <SignInForm />;
+}

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,0 +1,7 @@
+import { SignUpForm } from "@/modules/auth/components/sign-up-form";
+import { requireNoAuth } from "@/modules/auth/lib/auth.utils";
+
+export default async function SignUpPage() {
+  await requireNoAuth();
+  return <SignUpForm />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "@/modules/layout/components/providers";
 import "./globals.css";
+import { Toaster } from "@/components/ui/sonner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          <Toaster />
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { ThemeToggle } from "@/components/theme-toggle";
+import { requireAuth } from "@/modules/auth/lib/auth.utils";
 
-export default function Home() {
+export default async function Home() {
+  await requireAuth();
   return <ThemeToggle />;
 }

--- a/src/modules/auth/components/sign-in-form.tsx
+++ b/src/modules/auth/components/sign-in-form.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { Spinner } from "@/components/ui/spinner";
+
+const signInFormSchema = z.object({
+  email: z.email("Please enter a valid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+type SignInFormValues = z.infer<typeof signInFormSchema>;
+
+export function SignInForm() {
+  const router = useRouter();
+
+  const form = useForm<SignInFormValues>({
+    resolver: zodResolver(signInFormSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+
+  const onSubmit = async (data: SignInFormValues) => {
+    await authClient.signIn.email(
+      {
+        email: data.email,
+        password: data.password,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Successfully signed in!");
+          router.push("/");
+        },
+        onError: (ctx) => {
+          toast.error(
+            ctx?.error?.message || "Failed to sign in. Please try again."
+          );
+        },
+      }
+    );
+  };
+
+  const isPending = form.formState.isSubmitting;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle>Welcome Back!</CardTitle>
+          <CardDescription>Sign in to your account to continue</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+              <div className="grid gap-6">
+                <div className="grid gap-6">
+                  <FormField
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder="you@example.com"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Password</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder="••••••••"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button type="submit" className="w-full" disabled={isPending}>
+                    {isPending ? (
+                      <>
+                        <Spinner className="size-4" />
+                        Signing In...
+                      </>
+                    ) : (
+                      "Sign In"
+                    )}
+                  </Button>
+                </div>
+                <div className="text-center text-sm">
+                  Don&apos;t have an account?{" "}
+                  <Link
+                    href="/auth/sign-up"
+                    className="underline underline-offset-4"
+                  >
+                    Sign Up
+                  </Link>
+                </div>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/auth/components/sign-up-form.tsx
+++ b/src/modules/auth/components/sign-up-form.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormLabel,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/modules/auth/lib/auth-client";
+import { Spinner } from "@/components/ui/spinner";
+
+const signUpFormSchema = z
+  .object({
+    email: z.email("Please enter a valid email address"),
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+type SignUpFormValues = z.infer<typeof signUpFormSchema>;
+
+export function SignUpForm() {
+  const router = useRouter();
+
+  const form = useForm<SignUpFormValues>({
+    resolver: zodResolver(signUpFormSchema),
+    defaultValues: {
+      email: "",
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const onSubmit = async (data: SignUpFormValues) => {
+    await authClient.signUp.email(
+      {
+        name: data.email,
+        email: data.email,
+        password: data.password,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Account created successfully!");
+          router.push("/");
+        },
+        onError: (ctx) => {
+          toast.error(
+            ctx?.error?.message || "Something went wrong. Please try again."
+          );
+        },
+      }
+    );
+  };
+
+  const isPending = form.formState.isSubmitting;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle>Get Started</CardTitle>
+          <CardDescription>Create your account to get started</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+              <div className="grid gap-6">
+                <div className="grid gap-6">
+                  <FormField
+                    control={form.control}
+                    name="email"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Email</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="email"
+                            placeholder="you@example.com"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Password</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder="••••••••"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="confirmPassword"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Confirm Password</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            placeholder="••••••••"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button type="submit" className="w-full" disabled={isPending}>
+                    {isPending ? (
+                      <>
+                        <Spinner className="size-4" />
+                        Signing Up...
+                      </>
+                    ) : (
+                      "Sign Up"
+                    )}
+                  </Button>
+                </div>
+                <div className="text-center text-sm">
+                  Already have an account?{" "}
+                  <Link
+                    href="/auth/sign-in"
+                    className="underline underline-offset-4"
+                  >
+                    Sign In
+                  </Link>
+                </div>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/modules/auth/lib/auth.ts
+++ b/src/modules/auth/lib/auth.ts
@@ -14,6 +14,7 @@ export const auth = betterAuth({
   }),
   emailAndPassword: {
     enabled: true,
+    autoSignIn: true,
   },
 
   /**

--- a/src/modules/auth/lib/auth.utils.ts
+++ b/src/modules/auth/lib/auth.utils.ts
@@ -1,0 +1,27 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { auth } from "@/modules/auth/lib/auth";
+
+export const requireAuth = async () => {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    redirect("/auth/sign-in");
+  }
+
+  return session;
+};
+
+export const requireNoAuth = async () => {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (session) {
+    redirect("/");
+  }
+
+  return session;
+};

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -1,4 +1,6 @@
-import { initTRPC } from "@trpc/server";
+import { auth } from "@/modules/auth/lib/auth";
+import { initTRPC, TRPCError } from "@trpc/server";
+import { headers } from "next/headers";
 import { cache } from "react";
 import superjson from "superjson";
 export const createTRPCContext = cache(async () => {
@@ -21,3 +23,16 @@ const t = initTRPC.create({
 export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;
 export const baseProcedure = t.procedure;
+export const protectedProcedure = baseProcedure.use(async ({ ctx, next }) => {
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (!session) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "You must be logged in to access this resource.",
+    });
+  }
+  return next({ ctx: { ...ctx, auth: session } });
+});


### PR DESCRIPTION
This commit introduces the sign-in and sign-up functionality with the necessary UI components and pages.

- Adds `SignInForm` and `SignUpForm` components with form validation and submission handling.
- Creates `/auth/sign-in` and `/auth/sign-up` pages.
- Implements `requireAuth` and `requireNoAuth` utility functions to protect routes.
- Adds a `protectedProcedure` to the tRPC setup for authenticated endpoints.
- Enables `autoSignIn` for a better user experience after signing up.
- Integrates `sonner` for toast notifications to provide feedback to the user.