### PR TITLE
Fix: Incorrect error message color in dark mode (Issue #12)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,8 +78,8 @@
   --muted-foreground: oklch(0.6268 0 0);
   --accent: oklch(0.3211 0 0);
   --accent-foreground: oklch(0.8109 0 0);
-  --destructive: oklch(0.594 0.0443 196.0233);
-  --destructive-foreground: oklch(0.1797 0.0043 308.1928);
+  --destructive: oklch(0.6368 0.2078 25.3313);
+  --destructive-foreground: oklch(0.9851 0 0);
   --border: oklch(0.252 0 0);
   --input: oklch(0.252 0 0);
   --ring: oklch(0.7214 0.1337 49.9802);


### PR DESCRIPTION
## Fix: Incorrect error message color in dark mode (Issue #12)

### Description
This PR resolves the issue where form validation error messages in dark mode appeared in green instead of red, creating inconsistent and confusing feedback for users. The root cause was the incorrect `--destructive` and `--destructive-foreground` color values defined in `src/app/globals.css` under the dark mode section.

### Changes Made
- Updated dark mode variables for `--destructive` and `--destructive-foreground` to use proper red tones consistent with light mode.
- Removed the previous blue-green color values causing incorrect styling.
- Verified consistent behavior across sign-in and sign-up forms.

### Result
- Error messages now appear in red with correct contrast in both light and dark modes.
- Improves UI consistency, accessibility, and aligns with standard error state conventions.

### References
Fixes #12
